### PR TITLE
Use standard rust functions where possible, rename (u32, u32) to LineId

### DIFF
--- a/src/main.rs
+++ b/src/main.rs
@@ -396,14 +396,9 @@ fn walk_collision(
     min_lines: u32,
     results_hash: &DashMap<u64, Collision>,
 ) {
-    for l_idx in 0..(collisions.len() - 1) {
-        for r_idx in l_idx..collisions.len() {
-            if let Some(coll) = maximize_collision(
-                file_hashes,
-                &collisions[l_idx],
-                &collisions[r_idx],
-                min_lines,
-            ) {
+    for (i, l_id) in collisions[0..(collisions.len() - 1)].iter().enumerate() {
+        for r_id in &collisions[i + 1..] {
+            if let Some(coll) = maximize_collision(file_hashes, l_id, r_id, min_lines) {
                 match results_hash.entry(coll.key) {
                     Entry::Occupied(mut o) => o.get_mut().start_lines.extend(coll.start_lines),
                     Entry::Vacant(o) => {

--- a/src/main.rs
+++ b/src/main.rs
@@ -76,24 +76,23 @@ fn file_signatures(filename: &str) -> Vec<u64> {
 /// in the collision hash.
 fn rolling_hashes(file_signatures: &[u64], min_lines: usize) -> Vec<(u64, u32)> {
     let mut rc = vec![];
+    let mut prev_hash: u64 = 0;
 
-    if file_signatures.len() > min_lines {
-        let num_lines = file_signatures.len() - min_lines;
-        let mut prev_hash: u64 = 0;
-        for i in 0..num_lines {
-            let mut s = DefaultHasher::new();
-            for n in file_signatures.iter().skip(i).take(min_lines) {
-                n.hash(&mut s);
-            }
-            let digest = s.finish();
-
-            if prev_hash != digest {
-                rc.push((digest, i as u32));
-            }
-
-            prev_hash = digest;
+    for (i, window) in file_signatures.windows(min_lines).enumerate() {
+        let mut s = DefaultHasher::new();
+        for n in window {
+            n.hash(&mut s);
         }
+
+        let digest = s.finish();
+
+        if prev_hash != digest {
+            rc.push((digest, i as u32));
+        }
+
+        prev_hash = digest;
     }
+
     rc
 }
 

--- a/src/main.rs
+++ b/src/main.rs
@@ -50,7 +50,7 @@ fn file_signatures(filename: &str) -> Vec<u64> {
     let mut buf: Vec<u8> = vec![];
 
     loop {
-        match reader.read_until('\n' as u8, &mut buf) {
+        match reader.read_until(b'\n', &mut buf) {
             Ok(num_bytes) => {
                 if num_bytes == 0 {
                     return rc;
@@ -359,7 +359,7 @@ fn print_report(
 
                 if opts.print {
                     print_dup_text(
-                        &*file_lookup_locked.id_to_name(p.start_lines[0usize].file_id),
+                        &file_lookup_locked.id_to_name(p.start_lines[0usize].file_id),
                         p.start_lines[0usize].line_number as usize,
                         p.num_lines as usize,
                     );

--- a/src/main.rs
+++ b/src/main.rs
@@ -202,13 +202,8 @@ impl Collision {
     /// results and wondering what the input looked like.
     fn scrub(&mut self) {
         // Remove duplicates from each by sorting and then dedup
-        self.files.sort_by(|a, b| {
-            if a.1 == b.1 {
-                a.0.cmp(&b.0) // Number match, order by file name
-            } else {
-                a.1.cmp(&b.1) // Numbers don't match, order by number
-            }
-        });
+        self.files
+            .sort_by(|a, b| a.1.cmp(&b.1).then_with(|| a.0.cmp(&b.0)));
         self.files.dedup();
         self.remove_overlap_same_file();
 
@@ -468,15 +463,10 @@ fn process_report(
     }
 
     printable_results.par_sort_unstable_by(|a, b| {
-        if a.num_lines == b.num_lines {
-            if a.files[0].1 == b.files[0].1 {
-                a.files[0].0.cmp(&b.files[0].0)
-            } else {
-                a.files[0].1.cmp(&b.files[0].1)
-            }
-        } else {
-            a.num_lines.cmp(&b.num_lines)
-        }
+        a.num_lines
+            .cmp(&b.num_lines)
+            .then_with(|| a.files[0].1.cmp(&b.files[0].1))
+            .then_with(|| a.files[0].0.cmp(&b.files[0].0))
     });
 
     print_report(&printable_results, opts, ignore_hashes);


### PR DESCRIPTION
Using `Dashmap::entry` instead of
```
if map.contains_key(&key) {
    map.get()
} else {
    map.insert()
}
```
is faster.